### PR TITLE
famfile tab or space delim

### DIFF
--- a/pwas/genotype.py
+++ b/pwas/genotype.py
@@ -105,7 +105,7 @@ def _create_fam_link_or_fix_it(original_fam_file_path, fixed_fam_file_path):
     if os.path.exists(fixed_fam_file_path):
         return
 
-    fam_df = pd.read_csv(original_fam_file_path, sep = ' ', header = None)
+    fam_df = pd.read_csv(original_fam_file_path, sep = '\s+', header = None)
     
     if np.issubdtype(fam_df.iloc[:, 5].dtype, np.number):
         # The FAM file seems ok. Can just create a link for it

--- a/pwas/genotype.py
+++ b/pwas/genotype.py
@@ -119,7 +119,7 @@ def _create_fam_link_or_fix_it(original_fam_file_path, fixed_fam_file_path):
             fam_df.iloc[:, 5] = np.nan
                     
         try:
-            fam_df.to_csv(fixed_fam_file_path, sep = ' ', index = False, header = False)
+            fam_df.to_csv(fixed_fam_file_path, sep = '\s+', index = False, header = False)
         except OSError as e:
             if e.errno == 17:
                 log('%s: already exists after all.' % fixed_fam_file_path)


### PR DESCRIPTION
Use "\s+" instead of " " as a delimiter for read_csv so that the famfile recognizes by spaces and tabs.